### PR TITLE
Fixes to the tg68k. Fixes #67 - glitch in Nexus7, etc.

### DIFF
--- a/rtl/tg68k/TG68KdotC_Kernel.vhd
+++ b/rtl/tg68k/TG68KdotC_Kernel.vhd
@@ -529,11 +529,15 @@ begin
 	elsif set(briefext) = '1' then
 	  rf_dest_addr <= brief(15 downto 12);
 	elsif set(get_bfoffset) = '1' then
-	  rf_dest_addr <= sndOPC(9 downto 6);
+	  if opcode(15 downto 12) = "1110" then
+		rf_dest_addr <= '0' & sndOPC(8 downto 6);
+	  else
+		rf_dest_addr <= sndOPC(9 downto 6);
+	  end if;
 	elsif dest_2ndHbits = '1' then
-	  rf_dest_addr <= sndOPC(15 downto 12);
+	  rf_dest_addr <= '0' & sndOPC(14 downto 12);
 	elsif set(write_reminder) = '1' then
-	  rf_dest_addr <= sndOPC(3 downto 0);
+	  rf_dest_addr <= '0' & sndOPC(2 downto 0);
 	elsif setstackaddr = '1' then
 	  rf_dest_addr <= "1111";
 	elsif dest_hbits = '1' then
@@ -559,9 +563,9 @@ begin
 		rf_source_addr <= movem_regaddr;
 	  end if;
 	elsif source_2ndLbits = '1' then
-	  rf_source_addr <= sndOPC(3 downto 0);
+	  rf_source_addr <= '0' & sndOPC(2 downto 0);
 	elsif source_2ndHbits = '1' then
-	  rf_source_addr <= sndOPC(15 downto 12);
+	  rf_source_addr <= '0' & sndOPC(14 downto 12);
 	elsif source_lowbits = '1' then
 	  rf_source_addr <= source_areg & opcode(2 downto 0);
 	elsif exec(linksp) = '1' then


### PR DESCRIPTION
These issues were picked up by Toni Wilen's cputester.
Source/Destination register bits suffered from some confusion when an instructions that could only work with Data registers and had a bit set for address register. The result of this confusion was manifesting itself as wrong results or even writing the results into Address registers rather than Data registers.

This solves the texture corruption noted in:
https://github.com/rkrajnc/minimig-mist/issues/67
and I've noticed that another demo runs fine with the patch (at least on MiSTer):
https://demozoo.org/productions/32792/

According to @retrofun  this has been tested on MIST and resolves the said issue. https://github.com/retrofun/minimig-mist/pull/2#issuecomment-544207071

Some concrete samples of misconstructed opcodes causing issues:

Bitfield instructions:
bfchg eac0 31fe ... 2nd word should be 01fe since bits 15-12 of the second word should be 0. No dest in this opcode.
bfclr ecc2 ec68 ... 2nd word should be 0c68 since bits 15-12 of the second word should be 0. No dest in this opcode.
bfset eec0 8fc4 ... 2nd word should be 0fc4 since bits 15-12 of the second word should be 0. No dest in this opcode.
bftst e8c3 3a9a ... 2nd word should be 0a9a since bits 15-12 of the second word should be 0. No dest in this opcode.

bfexts ebc0 f094 ... 2nd word should be 7094 since bit 15 of the second word should be 0 - makes it write into An.
bfextu e9c0 116b ... bfextu d0{#5:d3},d1 ... if Dw(bit 5)=1 bits 4,3 should be 0. Also, if Do(bit 11)=1 bits 10,9 should be 0.
bfffo edc0 d771 ... 2nd word should be 5771 since bit 15 of the second word should be 0 - makes it write into An.

bfins efc0 7ee1 ... if Do(bit 11)=1 bits 10,9 should be 0. Also, if Dw(bit 5)=1 bits 4,3 should be 0.

Division and multiplication:
divul.l d0,d6:d0 - 4c40 000e ... Result written into A6 rather than D6.
mulu.l d0,d1:d0 - 4c00 05e9 ... A1: modified 00000080 -> 00000000 but expected no modifications
