### PR TITLE
Denise/Lisa read color table, BPLCON2 RDRAM

### DIFF
--- a/rtl/minimig/denise.v
+++ b/rtl/minimig/denise.v
@@ -61,6 +61,7 @@ parameter BPLCON3  = 9'h106;
 parameter BPLCON4  = 9'h10c;
 parameter DENISEID = 9'h07c;
 parameter BPL1DAT  = 9'h110;
+parameter COLORBASE = 9'h180;
 
 
 // local signals
@@ -83,14 +84,15 @@ reg    [7:0] clut_data;    // colour table colour select in
 reg    window;          // window enable signal
 
 wire  [15:0] deniseid_out;   // deniseid data_out
-wire  [15:0] col_out;      // colision detection data_out
+wire  [15:0] col_out;      // collision detection data_out
+wire  [15:0] rgb_out;      // RGB data_out (rdram)
 
 reg    display_ena;          // in OCS sprites are visible between first write to BPL1DAT and end of scanline
 
 //--------------------------------------------------------------------------------------
 
-// data out mulitplexer
-assign data_out = col_out | deniseid_out;
+// data out multiplexer
+assign data_out = col_out | deniseid_out | rgb_out;
 
 //--------------------------------------------------------------------------------------
 
@@ -166,6 +168,7 @@ end
 
 // BPLCON2 register
 reg  [16-1:0] bplcon2;    // bplcon2 register
+wire          rdram;      // read the color table instead of writing to it
 wire          killehb;    // disable ehb mode
 
 always @(posedge clk) begin
@@ -177,7 +180,12 @@ always @(posedge clk) begin
   end
 end
 
-assign killehb  = bplcon2[9] && ecs;
+assign rdram = bplcon2[8] & aga;
+assign rgb_out = (reg_address_in[8:6] == COLORBASE[8:6]) && rdram
+                   ? {4'b0000, loct ? {clut_rgb[19:16], clut_rgb[11:8], clut_rgb[3:0]}
+                                    : {clut_rgb[23:20], clut_rgb[15:12], clut_rgb[7:4]}}
+                   : 16'h0000;
+assign killehb = bplcon2[9] & ecs;
 
 // BPLCON3 register
 reg  [16-1:0] bplcon3;    // bplcon3 register
@@ -380,6 +388,7 @@ denise_colortable clut0
   .clk7_en(clk7_en),
   .reg_address_in(reg_address_in),
   .data_in(data_in[11:0]),
+  .rdram(rdram),
   .select(clut_data),
   .bplxor(bplxor),
   .bank(bank),

--- a/rtl/minimig/denise_colortable.v
+++ b/rtl/minimig/denise_colortable.v
@@ -10,10 +10,11 @@ module denise_colortable
   input  wire           clk7_en,          // 7MHz clock enable
   input  wire [  9-1:1] reg_address_in,   // register adress inputs
   input  wire [ 12-1:0] data_in,          // bus data in
+  input  wire           rdram,            // read the color table instead of writing to it
   input  wire [  8-1:0] select,           // colour select input
   input  wire [  8-1:0] bplxor,           // clut address xor value
   input  wire [  3-1:0] bank,             // color bank select
-  input  wire           loct,             // 12-bit pallete select
+  input  wire           loct,             // 12-bit palette select
   input  wire           ehb_en,           // EHB enable
   output reg  [ 24-1:0] rgb               // RGB output
 );
@@ -27,10 +28,10 @@ wire [ 8-1:0] select_xored = select;// ^ bplxor;
 
 // color ram
 wire [ 8-1:0] wr_adr = {bank[2:0], reg_address_in[5:1]};
-wire          wr_en  = (reg_address_in[8:6] == COLORBASE[8:6]) && clk7_en;
+wire          wr_en  = (reg_address_in[8:6] == COLORBASE[8:6]) && clk7_en && !rdram;
 wire [32-1:0] wr_dat = {4'b0, data_in[11:0], 4'b0, data_in[11:0]};
 wire [ 4-1:0] wr_bs  = loct ? 4'b0011 : 4'b1111;
-wire [ 8-1:0] rd_adr = ehb_en ? {3'b000, select_xored[4:0]} : select_xored;
+wire [ 8-1:0] rd_adr = rdram ? wr_adr : ehb_en ? {3'b000, select_xored[4:0]} : select_xored;
 wire [32-1:0] rd_dat;
 reg           ehb_sel;
 


### PR DESCRIPTION
Implements AGA read color table feature, BPLCON2 RDRAM.

Fixes AGA detection for some demos (made with Demomaniac demo maker),
see http://www.atari-forum.com/viewtopic.php?f=117&t=32761&start=1325